### PR TITLE
Lower go directive to 1.24 and test floor + stable in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,28 +1,49 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
   pull_request:
-    branches: [ "main" ]
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
-
-  build:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The floor declared in go.mod and the current stable release.
+        go: ["1.24.x", "stable"]
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: stable
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go }}
+          check-latest: true
 
-    - name: Build
-      run: go build -v ./...
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
 
-    - name: Test
-      run: go test -v ./...
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race -cover ./...
+
+      # Analysis tools track current Go; run them once, on the stable leg.
+      - name: Staticcheck
+        if: matrix.go == 'stable'
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          staticcheck ./...
+
+      - name: Vulnerability check
+        if: matrix.go == 'stable'
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/pascalallen/hmac/v2
 
-go 1.26
+go 1.24


### PR DESCRIPTION
Closes #3. The `go` directive is a viral floor for importers; 1.24 is what the module actually needs. CI now matches pgqueue/pubsub: gofmt, vet, `go test -race -cover` on 1.24.x + stable, staticcheck and govulncheck on the stable leg. Verified locally with `GOTOOLCHAIN=go1.24.0 go test -race ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)